### PR TITLE
Add fluctuo's proprietary API

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Places to access collections of GTFS and other transit and multimodal data
 
 #### Proprietary (non-standard) vendor APIs
 - [CityBikes](http://api.citybik.es) - REST API for aggregated bikeshare data from around the world. Powered by [pyBikes](https://github.com/eskerda/pybikes).
+- [fluctuo Data Flow](https://fluctuo.com/data-flow/) - Realtime vehicles location API. Exhaustive and reliable standardized data on free-floating mobility services (bikes, kick-scooters & motor-scooters) available on real-time.
 
 ### Software for Creating APIs
 


### PR DESCRIPTION
Hello,
I'm the CTO and founder of http://fluctuo.com. I permit myself to add the GraphQL API (https://fluctuo.com/data-flow/) we propose.
We currenctly integrate more than 80 networks (bikes, scooters, moped, cars, worldwide).
It's a paid API but there are a generous free plan. 

Thanks